### PR TITLE
Add CI workflow to test Go code

### DIFF
--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -1,0 +1,104 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/test-go-task.md
+name: Test Go
+
+env:
+  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
+  GO_VERSION: "1.19"
+
+# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+on:
+  create:
+  push:
+    paths:
+      - ".github/workflows/test-go-task.ya?ml"
+      - ".github/.?codecov.ya?ml"
+      - "dev/.?codecov.ya?ml"
+      - ".?codecov.ya?ml"
+      - "**/go.mod"
+      - "**/go.sum"
+      - "Taskfile.ya?ml"
+      - "**.go"
+      - "**/testdata/**"
+  pull_request:
+    paths:
+      - ".github/workflows/test-go-task.ya?ml"
+      - ".github/.?codecov.ya?ml"
+      - "dev/.?codecov.ya?ml"
+      - ".?codecov.ya?ml"
+      - "**/go.mod"
+      - "**/go.sum"
+      - "Taskfile.ya?ml"
+      - "**.go"
+      - "**/testdata/**"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 11 * * WED"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[
+            "${{ github.event_name }}" != "create" ||
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
+
+  test:
+    name: test (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: ./
+            codecov-flags: unit
+
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Run tests
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
+        run: task go:test
+
+      - name: Send unit tests coverage to Codecov
+        if: runner.os == 'Linux'
+        uses: codecov/codecov-action@v3
+        with:
+          file: ${{ matrix.module.path }}coverage_unit.txt
+          flags: ${{ matrix.module.codecov-flags }}
+          fail_ci_if_error: ${{ github.repository == 'arduino/go-win32-utils' }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /node_modules/
+go-win32-utils
+go-win32-utils.exe

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![Sync Labels status](https://github.com/arduino/go-win32-utils/actions/workflows/sync-labels.yml/badge.svg)](https://github.com/arduino/go-win32-utils/actions/workflows/sync-labels.yml)
 [![Check Markdown status](https://github.com/arduino/go-win32-utils/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/arduino/go-win32-utils/actions/workflows/check-markdown-task.yml)
 [![Check Taskfiles status](https://github.com/arduino/go-win32-utils/actions/workflows/check-taskfiles.yml/badge.svg)](https://github.com/arduino/go-win32-utils/actions/workflows/check-taskfiles.yml)
+[![Test Go status](https://github.com/arduino/go-win32-utils/actions/workflows/test-go-task.yml/badge.svg)](https://github.com/arduino/go-win32-utils/actions/workflows/test-go-task.yml)
+[![Codecov](https://codecov.io/gh/arduino/go-win32-utils/branch/main/graph/badge.svg)](https://codecov.io/gh/arduino/go-win32-utils)
 
 This library contains some useful calls to win32 API that are not available on the standard golang library.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,6 +1,21 @@
 # See: https://taskfile.dev/#/usage
 version: "3"
 
+vars:
+  # Path of the project's primary Go module:
+  DEFAULT_GO_MODULE_PATH: ./
+  DEFAULT_GO_PACKAGES:
+    sh: |
+      echo $(
+        cd {{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}} &&
+        go list ./... | tr '\n' ' ' ||
+        echo '"ERROR: Unable to discover Go packages"'
+      )
+  # `-ldflags` flag to use for `go build` command
+  LDFLAGS:
+  # `-ldflags` flag to use for `go test` command
+  TEST_LDFLAGS:
+
 tasks:
   docs:generate:
     desc: Create all generated documentation content
@@ -87,3 +102,18 @@ tasks:
     desc: Install dependencies managed by npm
     cmds:
       - npm install
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/test-go-task/Taskfile.yml
+  go:test:
+    desc: Run unit tests
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
+    cmds:
+      - |
+        go test \
+          -v \
+          -short \
+          -run '{{default ".*" .GO_TEST_REGEX}}' \
+          {{default "-timeout 10m -coverpkg=./... -covermode=atomic" .GO_TEST_FLAGS}} \
+          -coverprofile=coverage_unit.txt \
+          {{.TEST_LDFLAGS}} \
+          {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}


### PR DESCRIPTION
On every push and pull request that affects relevant files, run the project's [Go](https://golang.org/) code tests.